### PR TITLE
fix: update for Python3

### DIFF
--- a/stickyex.py
+++ b/stickyex.py
@@ -46,7 +46,7 @@ def main():
     try:
         fp = open(fn, 'rb')
     except Exception as e:
-        print e
+        print(e)
         return -1
 
     # make the destination directory
@@ -55,7 +55,7 @@ def main():
         try:
             os.mkdir(dst)
         except Exception as e:
-            print e
+            print(e)
 
     # we need an initial name for the first exported file
     fn = dst + "STICKY-0.txt"
@@ -64,7 +64,7 @@ def main():
     try:
         out = open(fn, 'w')
     except Exception as e:
-        print e
+        print(e)
         return -1
 
     # track which note we are on and use a state machine to detect the start of a new note
@@ -113,11 +113,11 @@ def main():
                     out.close()
                     out = open(fn, 'w')
                 except Exception as e:
-                    print e
+                    print(e)
                 # write the text from the note to the exported file
-                print >> out, text
+                print(text, file=out)
             else:
-                print >> out, text
+                print(text, file=out)
     # close open files
     fp.close()
     out.close()


### PR DESCRIPTION
Hi, this looks like a promising utility, but I can't get it to work (with my limited knowledge of python).
First I reformatted the print function calls for Python3 (see my PR). However, I get this error while trying to read the input file:

```bash
  File "/Users/klokie/Sites/stickyex/./stickyex.py", line 75, in main
    if '}\x01' in line:
       ^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'str'
```

Can you offer any clues as to how to read the (binary-like) text file in UTF-8 mode that will work with Mac OS Ventura and Python 3.11? Thanks!